### PR TITLE
Make /meetup/next/ redirect to latest meetup post

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ gem "minima", "~> 2.0"
 group :jekyll_plugins do
    gem "jekyll-feed", "~> 0.6"
    gem "jekyll-paginate", "~> 1.1"
+   gem "jekyll-redirect-from", "~> 0.10.0"
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,6 +20,8 @@ GEM
     jekyll-feed (0.9.2)
       jekyll (~> 3.3)
     jekyll-paginate (1.1.0)
+    jekyll-redirect-from (0.10.0)
+      jekyll (>= 2.0)
     jekyll-sass-converter (1.5.0)
       sass (~> 3.4)
     jekyll-watch (1.5.0)
@@ -49,6 +51,7 @@ DEPENDENCIES
   jekyll (= 3.4.3)
   jekyll-feed (~> 0.6)
   jekyll-paginate (~> 1.1)
+  jekyll-redirect-from (~> 0.10.0)
   minima (~> 2.0)
   tzinfo-data
 

--- a/_config.yml
+++ b/_config.yml
@@ -6,6 +6,7 @@ gems:
   - rouge
   - jekyll-watch
   - jekyll-paginate
+  - jekyll-redirect-from
 exclude:
   - Gemfile
   - Gemfile.lock

--- a/_posts/2017-05-30-meetup-18.md
+++ b/_posts/2017-05-30-meetup-18.md
@@ -9,7 +9,7 @@ categories:
   - blog
 logo: /assets/meetups/18/logo.png
 permalink: /meetup/18/
-
+redirect_from: /meetup/next/
 ---
 
 30 мая в 19:30 в пабе ["Литера Б"]({% link pages/litera_b.md %}) пройдет 18-я встреча ИТ сообщества 


### PR DESCRIPTION
Патч для использования ссылки на последний митап нашим ботом:
https://github.com/deeprefactoring/deeprefactoring-bot/
Патч для бота, добавляющий команду работы с этой ссылкой:
https://github.com/deeprefactoring/deeprefactoring-bot/pull/7

Каждый раз при добавлении анонса о новом митапе на сайте, нужно будет в шаблоне предыдущего убрать строку
```
redirect_from: /meetup/next/
```
и перенести ее в новый шаблон.

Usage: https://github.com/jekyll/jekyll-redirect-from